### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  # Maintain dependencies for Docker
+  - package-ecosystem: "docker"
+    # Location of Dockerfile
+    directory: "/docker/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for Gradle
+  - package-ecosystem: "gradle"
+    # Location of build.gradle
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
.github/dependabot.yml: Configure Dependabot to bump dependencies for
both Docker and Gradle.